### PR TITLE
feat: Add rarity labels for trinkets

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 use num_rational::Rational32;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 const TRADING_POST_SALES_COMMISSION: i32 = 15; // %
 
@@ -68,14 +69,6 @@ pub struct Item {
 }
 
 impl Item {
-    pub fn display_name(&self) -> String {
-        if &self.type_name == "Trinket" {
-            format!("{} ({})", &self.name, &self.rarity)
-        } else {
-            self.name.clone()
-        }
-    }
-
     pub fn vendor_cost(&self) -> Option<i32> {
         let name = &self.name;
 
@@ -146,6 +139,16 @@ impl Item {
             name: name.to_string(),
             vendor_value,
             ..Default::default()
+        }
+    }
+}
+
+impl fmt::Display for Item {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if &self.type_name == "Trinket" {
+            write!(f, "{} ({})", &self.name, &self.rarity)
+        } else {
+            write!(f, "{}", &self.name)
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -68,6 +68,14 @@ pub struct Item {
 }
 
 impl Item {
+    pub fn display_name(&self) -> String {
+        if &self.type_name == "Trinket" {
+            format!("{} ({})", &self.name, &self.rarity)
+        } else {
+            self.name.clone()
+        }
+    }
+
     pub fn vendor_cost(&self) -> Option<i32> {
         let name = &self.name;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -143,6 +143,8 @@ impl Item {
     }
 }
 
+// When printing an item, add rarity if a trinket, as most trinkets use the same
+// name for different rarities
 impl fmt::Display for Item {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if &self.type_name == "Trinket" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!(
             "Shopping list for {} x {} = {} profit ({} / step)",
             profitable_item.count,
-            &item.name,
+            &item.display_name(),
             copper_to_string(profitable_item.profit.to_integer()),
             profitable_item.profit_per_crafting_step().to_integer()
         );
@@ -256,8 +256,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ingredient_count_msg,
                 items_map
                     .get(ingredient_id)
-                    .map(|item| item.name.as_ref())
-                    .unwrap_or("???"),
+                    .map(|item| item.display_name())
+                    .unwrap_or("???".to_string()),
                 if *ingredient_source == crafting::Source::Vendor {
                     " (vendor)"
                 } else {
@@ -415,8 +415,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let item_id = profitable_item.id;
         let name = items_map
             .get(&item_id)
-            .map(|item| item.name.as_ref())
-            .unwrap_or("???");
+            .map(|item| item.display_name())
+            .unwrap_or("???".to_string());
 
         let recipe = recipes_map.get(&item_id).expect("Missing recipe");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!(
             "Shopping list for {} x {} = {} profit ({} / step)",
             profitable_item.count,
-            &item.display_name(),
+            &item,
             copper_to_string(profitable_item.profit.to_integer()),
             profitable_item.profit_per_crafting_step().to_integer()
         );
@@ -256,7 +256,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ingredient_count_msg,
                 items_map
                     .get(ingredient_id)
-                    .map(|item| item.display_name())
+                    .map(|item| item.to_string())
                     .unwrap_or("???".to_string()),
                 if *ingredient_source == crafting::Source::Vendor {
                     " (vendor)"
@@ -415,7 +415,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let item_id = profitable_item.id;
         let name = items_map
             .get(&item_id)
-            .map(|item| item.display_name())
+            .map(|item| item.to_string())
             .unwrap_or("???".to_string());
 
         let recipe = recipes_map.get(&item_id).expect("Missing recipe");

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,8 +256,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ingredient_count_msg,
                 items_map
                     .get(ingredient_id)
-                    .map(|item| item.to_string())
-                    .unwrap_or("???".to_string()),
+                    .map_or_else(|| "???".to_string(), |item| item.to_string()),
                 if *ingredient_source == crafting::Source::Vendor {
                     " (vendor)"
                 } else {
@@ -415,8 +414,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let item_id = profitable_item.id;
         let name = items_map
             .get(&item_id)
-            .map(|item| item.to_string())
-            .unwrap_or("???".to_string());
+            .map_or_else(|| "???".to_string(), |item| item.to_string());
 
         let recipe = recipes_map.get(&item_id).expect("Missing recipe");
 


### PR DESCRIPTION
Since many trinkets have the same names with different rarities, just
blanket apply a rarity label to trinkets, even if their name is unique.

Not sure if this is idiomatic rust - I had to read up to chapter 4 in the book to figure out how to make this work. The `"???".to_string()` made the compiler happy and seemed reasonable, but that should be trivial to type coerce?

I don't love that I'm cloning the heap string `self.name` when I'm using it immutably _anyway_ - you might know a better way to accomplish the same task. Is there a way to return a reference to the `format` output? Another method perhaps?