### PR TITLE
Check known recipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "serde_path_to_error",
  "structopt",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1288,6 +1289,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = "1.0"
 serde_path_to_error = "0.1"
 structopt = "0.3"
 tokio = { version = "1.0", features = ["full"] }
+toml = "0.4"

--- a/src/api.rs
+++ b/src/api.rs
@@ -48,6 +48,15 @@ pub struct Recipe {
     chat_link: String,
 }
 
+impl Recipe {
+    pub fn is_purchased(&self) -> bool {
+        self.flags.contains(&"LearnedFromItem".to_string())
+    }
+    pub fn is_automatic(&self) -> bool {
+        self.flags.contains(&"AutoLearned".to_string())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RecipeIngredient {
     pub item_id: u32,

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -258,6 +258,8 @@ pub fn calculate_crafting_profit(
                     _ => {
                         if let Some(known_recipes) = known_recipes {
                             used_recipes.insert(id, known_recipes.contains(&id));
+                        } else {
+                            used_recipes.insert(id, false);
                         }
                     }
                 }

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -259,6 +259,7 @@ pub fn calculate_crafting_profit(
                         if let Some(known_recipes) = known_recipes {
                             used_recipes.insert(id, known_recipes.contains(&id));
                         } else {
+                            // If we have no known recipes, assume we know none
                             used_recipes.insert(id, false);
                         }
                     }
@@ -578,8 +579,10 @@ impl TryFrom<gw2efficiency::Recipe> for Recipe {
             ));
         };
         // Any disciplines _except_ Achievement can be counted as known
-        // There are a few for regular disciplines, but they are mostly account bound for leg weapons
-        // Some Scribe WvW BPs which are useful too
+        // While some regular discipline precursor recipes must be learned, the
+        // outputs appear to be account bound anyway, so won't be on TP.
+        // There are some useful Scribe WvW BPs in the data, so ignoring all
+        // normal discipline recipes would catch those too.
         let source = if recipe.disciplines.contains(&"Achievement".to_string()) {
             RecipeSource::Achievement
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,9 +321,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             profitable_item.count, item_id
         );
 
-        let unknown_recipes: Vec<u32> = profitable_item.used_recipes.iter().filter_map(|(k, v)| {
-            if !*v {
-                Some(*k)
+        let unknown_recipes: Vec<u32> = profitable_item.used_recipes.iter().filter_map(|(id, known)| {
+            if !*known {
+                Some(*id)
             } else {
                 None
             }
@@ -333,7 +333,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "You can not craft this yet. Missing recipe id{}: {}",
                 if unknown_recipes.len() > 1 { "s" } else { "" },
                 unknown_recipes.iter()
-                    .map(|x| x.to_string())
+                    .map(|id| id.to_string())
                     .collect::<Vec<String>>()
                     .join(", ")
             );
@@ -506,9 +506,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .collect::<Vec<_>>()
                 .join("/"),
             item_id,
-            unknown_recipes: profitable_item.used_recipes.iter().filter_map(|(k, v)| {
-                if !*v {
-                    Some(*k)
+            unknown_recipes: profitable_item.used_recipes.iter().filter_map(|(id, known)| {
+                if !*known {
+                    Some(*id)
                 } else {
                     None
                 }
@@ -530,10 +530,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_row.name,
             output_row.disciplines,
             format!("{}", output_row.item_id),
-            format!("{}", output_row.unknown_recipes.iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
+            format!(
+                "{}",
+                output_row
+                    .unknown_recipes.iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
             ),
             copper_to_string(output_row.total_profit),
             format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,11 +478,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .cycle();
 
     let header = format!(
-        "{:<50} {:<15} {:<15} {:<15} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}",
+        "{:<50} {:<15} {:<15} {:<20} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}",
         "Name",
         "Disciplines",
         "Item id",
-        "Unk Recipe id",
+        "Req. Recipe Ids",
         "Total profit",
         "No. required",
         "Profit / item",
@@ -541,7 +541,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         let line = format!(
-            "{:<50} {:<15} {:<15} {:<15} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}",
+            "{:<50} {:<15} {:<15} {:<20} {:>15} {:>15} {:>15} {:>15} {:>15} {:>15}",
             output_row.name,
             output_row.disciplines,
             format!("{}", output_row.item_id),

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }).collect();
         if unknown_recipes.len() > 0 {
             println!(
-                "You can not craft this yet. Missing recipe id{}: {}",
+                "You {} craft this yet. Missing recipe id{}: {}",
+                match known_recipes {
+                    Some(_) => "can not",
+                    None => "may not be able to",
+                },
                 if unknown_recipes.len() > 1 { "s" } else { "" },
                 unknown_recipes.iter()
                     .map(|id| id.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }).collect();
         if unknown_recipes.len() > 0 {
             println!(
-                "You don't know how to craft this yet. Missing recipe{}: {}",
+                "You can not craft this yet. Missing recipe id{}: {}",
                 if unknown_recipes.len() > 1 { "s" } else { "" },
                 unknown_recipes.iter()
                     .map(|x| x.to_string())

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,9 +5,11 @@ use flate2::read::DeflateDecoder;
 use flate2::write::DeflateEncoder;
 use flate2::Compression;
 use futures::{stream, StreamExt};
+use serde_json;
 
 use std::fs::File;
 use std::path::Path;
+use std::collections::HashSet;
 
 const PARALLEL_REQUESTS: usize = 10;
 const MAX_PAGE_SIZE: i32 = 200; // https://wiki.guildwars2.com/wiki/API:2#Paging
@@ -157,4 +159,10 @@ where
     }
 
     Ok(result)
+}
+
+pub async fn fetch_account_recipes(key: &str) -> Result<HashSet<u32>, Box<dyn std::error::Error>> {
+    let url = format!("https://api.guildwars2.com/v2/account/recipes?access_token={}", key);
+    println!("Fetching {}", url);
+    Ok(reqwest::get(url).await?.json().await?)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -164,5 +164,10 @@ where
 pub async fn fetch_account_recipes(key: &str) -> Result<HashSet<u32>, Box<dyn std::error::Error>> {
     let url = format!("https://api.guildwars2.com/v2/account/recipes?access_token={}", key);
     println!("Fetching {}", url);
-    Ok(reqwest::get(url).await?.json().await?)
+    let result = reqwest::get(url).await?;
+    if result.status() != 200 {
+        let err: serde_json::value::Value = result.json().await?;
+        panic!("API error fetching recipe unlocks: {}", err["text"]);
+    }
+    Ok(result.json().await?)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -162,12 +162,18 @@ where
 }
 
 pub async fn fetch_account_recipes(key: &str) -> Result<HashSet<u32>, Box<dyn std::error::Error>> {
-    let url = format!("https://api.guildwars2.com/v2/account/recipes?access_token={}", key);
-    println!("Fetching {}", url);
+    let base = "https://api.guildwars2.com/v2/account/recipes?access_token=";
+    let url = format!("{}{}", base, key);
+    println!("Fetching {}{}", base, "<api-key>");
     let result = reqwest::get(url).await?;
-    if result.status() != 200 {
+    let status = result.status();
+    if status != 200 {
         let err: serde_json::value::Value = result.json().await?;
-        panic!("API error fetching recipe unlocks: {}", err["text"]);
+        let text = err
+            .get("text")
+            .and_then(|text| text.as_str())
+            .unwrap_or_else(|| status.as_str());
+        return Err(text.into());
     }
     Ok(result.json().await?)
 }


### PR DESCRIPTION
Fixes #13.

Not 100% yet; only shows the recipe id, not the id + name of the item to unlock the recipe. Still, good enough to be useful. Be aware there is some kind of cache on the API side, so an unlock may not immediately show up. Also doesn't seem possible to check discovery recipes (though, free). Also also, doesn't check if you have a character of the appropriate discipline + crafting level for non-unlocked recipes.

All that aside, already quite useful.

Based on the min sale branch as otherwise merging it would produce a conflict, which doesn't seem worth it. Any concerns re that branch?