### PR TITLE
Feat fixed value

### DIFF
--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -14,6 +14,7 @@ pub struct CraftingOptions {
     pub include_timegated: bool,
     pub include_ascended: bool,
     pub count: Option<i32>,
+    pub value: Option<i32>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -299,7 +300,9 @@ pub fn calculate_crafting_profit(
             break;
         };
 
-        let (buy_price, min_buy) = if let Some(buy_price) = tp_listings_map
+        let (buy_price, min_buy) = if let Some(price) = opt.value {
+            (Rational32::from(price), price)
+        } else if let Some(buy_price) = tp_listings_map
             .get_mut(&item_id)
             .unwrap_or_else(|| panic!("Missing listings for item id: {}", item_id))
             .sell(output_item_count.into())

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ struct Opt {
     #[structopt(short, long)]
     count: Option<i32>,
 
+    /// Calculate profit based on a fixed value instead of from buy orders
+    #[structopt(long)]
+    value: Option<i32>,
+
     /// Only show items craftable by this discipline or comma-separated list of disciplines (e.g. -d=Weaponsmith,Armorsmith)
     #[structopt(short = "d", long = "disciplines", use_delimiter = true)]
     filter_disciplines: Option<Vec<String>>,
@@ -239,6 +243,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         include_timegated: opt.include_timegated,
         include_ascended: opt.include_ascended,
         count: opt.count,
+        value: opt.value,
     };
 
     if let Some(item_id) = opt.item_id {


### PR DESCRIPTION
This one is useful for crafting to sell orders - I'd like to see something like this in eventually. I'm not sure if it needs any more work - for example, craft to all buy orders at that price and _then_ craft another `count` orders to sell? Anyway, I'm not crafting to sell orders, but I'd like the tool to support this particular case, if only to estimate profit and provide a shopping list.