### PR TITLE
Language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "structopt",
+ "strum",
  "tokio",
  "toml",
 ]
@@ -1076,6 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1243,28 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ tokio = { version = "1.0", features = ["full"] }
 toml = "0.4"
 phf = { version = "0.9", features = ["macros"] }
 lazy_static = "1.4"
+strum = { version = "0.23", features = ["derive"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,8 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use phf::{phf_set, phf_map};
+use strum::Display;
 
 use crate::config;
+use config::CONFIG;
 
 const TRADING_POST_SALES_COMMISSION: i32 = 15; // %
 
@@ -106,7 +108,7 @@ pub enum ItemType {
     Weapon,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Display)]
 pub enum ItemRarity {
     Junk,
     Basic,
@@ -117,19 +119,38 @@ pub enum ItemRarity {
     Ascended,
     Legendary,
 }
-// TODO: Localize
-impl fmt::Display for ItemRarity {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match &self {
-            ItemRarity::Junk => "Junk",
-            ItemRarity::Basic => "Basic",
-            ItemRarity::Fine => "Fine",
-            ItemRarity::Masterwork => "Masterwork",
-            ItemRarity::Rare => "Rare",
-            ItemRarity::Exotic => "Exotic",
-            ItemRarity::Ascended => "Ascended",
-            ItemRarity::Legendary => "Legendary",
-        })
+
+impl ItemRarity {
+    fn crafted_localized(&self) -> String {
+        let lang = CONFIG.lang.as_ref().unwrap_or(&config::Language::English);
+        // NOTE: these strings were extracted by hand from client crafting interface
+        match lang {
+            config::Language::English => match &self {
+                ItemRarity::Masterwork => "Master".to_string(),
+                _ => self.to_string(),
+            },
+            config::Language::Spanish => match &self {
+                ItemRarity::Masterwork => "maestro".to_string(),
+                ItemRarity::Rare => "excepcional".to_string(),
+                ItemRarity::Exotic => "exótico".to_string(),
+                ItemRarity::Ascended => "Ascendido".to_string(),
+                _ => self.to_string(),
+            },
+            config::Language::German => match &self {
+                ItemRarity::Masterwork => "Meister".to_string(),
+                ItemRarity::Rare => "Selten".to_string(),
+                ItemRarity::Exotic => "Exotisch".to_string(),
+                ItemRarity::Ascended => "Aufgestiegen".to_string(),
+                _ => self.to_string(),
+            },
+            config::Language::French => match &self {
+                ItemRarity::Masterwork => "Maître".to_string(),
+                // Rare is the same in French
+                ItemRarity::Exotic => "Exotique".to_string(),
+                ItemRarity::Ascended => "Elevé".to_string(),
+                _ => self.to_string(),
+            },
+        }
     }
 }
 
@@ -226,7 +247,7 @@ impl Item {
 impl fmt::Display for Item {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let ItemType::Trinket = &self.item_type {
-            write!(f, "{} ({})", &self.name, &self.rarity)
+            write!(f, "{} ({})", &self.name, &self.rarity.crafted_localized())
         } else {
             write!(f, "{}", &self.name)
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,8 @@ use std::fmt;
 
 use phf::{phf_set, phf_map};
 
+use crate::config;
+
 const TRADING_POST_SALES_COMMISSION: i32 = 15; // %
 
 pub fn subtract_trading_post_sales_commission(v: i32) -> Rational32 {
@@ -35,24 +37,30 @@ pub struct PriceInfo {
 }
 
 // types for /recipes
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Recipe {
     pub id: u32,
     pub output_item_id: u32,
     pub output_item_count: i32,
     time_to_craft_ms: i32,
-    pub disciplines: Vec<String>,
+    pub disciplines: Vec<config::Discipline>,
     min_rating: i32,
-    flags: Vec<String>,
+    flags: Vec<RecipeFlags>,
     pub ingredients: Vec<RecipeIngredient>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum RecipeFlags {
+    AutoLearned,
+    LearnedFromItem,
 }
 
 impl Recipe {
     pub fn is_purchased(&self) -> bool {
-        self.flags.contains(&"LearnedFromItem".to_string())
+        self.flags.contains(&RecipeFlags::LearnedFromItem)
     }
     pub fn is_automatic(&self) -> bool {
-        self.flags.contains(&"AutoLearned".to_string())
+        self.flags.contains(&RecipeFlags::AutoLearned)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,14 +3,13 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::{error::Error, fmt};
 use std::time::{Duration, SystemTime};
 
 use once_cell::sync::Lazy;
 use structopt::StructOpt;
 use serde::{Serialize, Deserialize};
 use toml;
-use strum::{Display, EnumString, EnumIter, IntoEnumIterator};
+use strum::{Display, EnumString, EnumVariantNames, VariantNames};
 
 use lazy_static::lazy_static;
 
@@ -79,7 +78,7 @@ impl Config {
 
         if let None = config.lang {
             if let Some(code) = file.lang {
-                config.lang = Language::from_code(&code).map_or_else(|e| {
+                config.lang = code.parse().map_or_else(|e| {
                     println!("Config file: {}", e);
                     None
                 }, |c| Some(c))
@@ -174,7 +173,7 @@ struct Opt {
     #[structopt(long)]
     threshold: Option<u32>,
 
-    #[structopt(short = "d", long = "disciplines", use_delimiter = true, help = &DISCIPLINES_HELP)]
+    #[structopt(short = "d", long = "disciplines", use_delimiter = true, help = &DISCIPLINES_HELP, parse(try_from_str = get_discipline))]
     filter_disciplines: Option<Vec<Discipline>>,
 
     /// Download recipes and items from the GW2 API, replacing any previously cached recipes and items
@@ -190,8 +189,9 @@ struct Opt {
     #[structopt(long, parse(from_os_str), help = &CONFIG_FILE_HELP)]
     config_file: Option<PathBuf>,
 
-    /// One of "en", "es", "de", "fr", or "zh". Defaults to "en"
-    #[structopt(long)]
+    /// One of "en", "es", "de", or "fr". Defaults to "en"
+    // /// One of "en", "es", "de", "fr", or "zh". Defaults to "en"
+    #[structopt(long, parse(try_from_str = get_lang))]
     lang: Option<Language>,
 }
 
@@ -229,17 +229,24 @@ static DISCIPLINES_HELP: Lazy<String> = Lazy::new(|| {
     format!(r#"Only show items craftable by this discipline or comma-separated list of disciplines (e.g. -d=Weaponsmith,Armorsmith)
 
 valid values: {}"#,
-        Discipline::iter().map(|d| d.to_string()).collect::<Vec<String>>().join(", ")
+        Discipline::VARIANTS.join(", ")
     )
 });
 
-#[derive(Debug)]
+#[derive(Debug, EnumString, EnumVariantNames)]
 pub enum Language {
+    #[strum(serialize="en")]
     English,
+    #[strum(serialize="es")]
     Spanish,
+    #[strum(serialize="de")]
     German,
+    #[strum(serialize="fr")]
     French,
-    Chinese
+    // If you read this and can help test the TP code and extract strings from the Chinese version,
+    // and would like to see this work in Chinese, please open an issue.
+    // #[strum(serialize="zh")]
+    // Chinese, // No lang client, and TP might have different data source anyway
 }
 impl Language {
     pub fn code(lang: &Option<Language>) -> Option<&str> {
@@ -249,39 +256,21 @@ impl Language {
                 Language::Spanish => Some("es"),
                 Language::German => Some("de"),
                 Language::French => Some("fr"),
-                Language::Chinese => Some("zh"),
+                //Language::Chinese => Some("zh"),
             }
         } else {
             None
         }
     }
-    pub fn from_code(code: &String) -> Result<Language, LanguageParseError> {
-        Language::from_str(code)
-    }
-}
-#[derive(Debug)]
-pub struct LanguageParseError;
-impl Error for LanguageParseError {}
-impl fmt::Display for LanguageParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Invalid language code selected")
-    }
-}
-impl FromStr for Language {
-    type Err = LanguageParseError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "en" => Ok(Language::English),
-            "es" => Ok(Language::Spanish),
-            "de" => Ok(Language::German),
-            "fr" => Ok(Language::French),
-            "zh" => Ok(Language::Chinese),
-            _ => Err(LanguageParseError),
-        }
-    }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Display, EnumString, EnumIter)]
+fn get_lang<Language: FromStr + VariantNames>(code: &str) -> Result<Language, Box<dyn std::error::Error>> {
+    Language::from_str(code).map_err(|_| format!(
+        "Invalid language: {} (valid values are {})", code, Language::VARIANTS.join(", ")
+    ).into())
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Display, EnumString, EnumVariantNames)]
 pub enum Discipline {
     Artificer,
     Armorsmith,
@@ -302,6 +291,12 @@ pub enum Discipline {
     Charge,
     Achievement,
     Growing,
+}
+
+fn get_discipline<Discipline: FromStr + VariantNames>(discipline: &str) -> Result<Discipline, Box<dyn std::error::Error>> {
+    Discipline::from_str(discipline).map_err(|_| format!(
+        "Invalid discipline: {} (valid values are {})", discipline, Discipline::VARIANTS.join(", ")
+    ).into())
 }
 
 fn ensure_dir(dir: &PathBuf) -> Result<&PathBuf, Box<dyn std::error::Error>> {

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -560,7 +560,7 @@ pub struct Recipe {
     pub id: Option<u32>,
     pub output_item_id: u32,
     pub output_item_count: i32,
-    pub disciplines: Vec<String>,
+    pub disciplines: Vec<config::Discipline>,
     pub ingredients: Vec<api::RecipeIngredient>,
     source: RecipeSource,
 }
@@ -602,7 +602,7 @@ impl TryFrom<gw2efficiency::Recipe> for Recipe {
         // outputs appear to be account bound anyway, so won't be on TP.
         // There are some useful Scribe WvW BPs in the data, so ignoring all
         // normal discipline recipes would catch those too.
-        let source = if recipe.disciplines.contains(&"Achievement".to_string()) {
+        let source = if recipe.disciplines.contains(&config::Discipline::Achievement) {
             RecipeSource::Achievement
         } else {
             RecipeSource::Automatic

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,14 +422,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             disciplines: recipe
                 .disciplines
                 .iter()
-                .map(|s| {
-                    if s == "Mystic Forge" {
-                        return "My".to_string();
-                    } else if &s[..1] == "A" {
-                        // take 1st and 3rd characters to distinguish armorer/artificer
-                        format!("{}{}", &s[..1], &s[2..3])
-                    } else {
-                        s[..1].to_string()
+                .map(|d| {
+                    let s = d.to_string();
+                    match &s[..1] {
+                        // take 1st and 7th characters to distinguish Merchant/Mystic Forge
+                        "M" => format!("{}{}", &s[..1], &s[6..7]),
+                        // take 1st and 3rd characters to distinguish Scribe/Salvage and
+                        // Armorsmith/Artificer/Achievement
+                        "A" | "S" => format!("{}{}", &s[..1], &s[2..3]),
+                        // take 1st and 4th characters to distinguish Chef/Charge
+                        "C" => format!("{}{}", &s[..1], &s[3..4]),
+                        l => l.to_string(),
                     }
                 })
                 .collect::<Vec<_>>()


### PR DESCRIPTION
Gives the item names in the selected language. Rust doesn't seem to have strong opinions on localization, so I ended up refactoring the configuration (been thinking about it anyway) to get the lang into a global so I could translate the rarity values... Anyway, WIP branch, but after pushing the config refactor it seems reasonable to push all the other side branches up for review.