### PR TITLE
feat: stable sorted ingredient list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::fs::File;
 use std::io::Read;
+use std::cmp::Ordering;
 
 mod api;
 mod crafting;
@@ -301,8 +302,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             copper_to_string(profitable_item.crafting_cost.to_integer()),
             copper_to_string(profitable_item.breakeven),
         );
+
         println!("============");
-        for ((ingredient_id, ingredient_source), ingredient) in &purchased_ingredients {
+        let mut sorted_ingredients: Vec<(&(u32, crafting::Source), &crafting::PurchasedIngredient)> = purchased_ingredients.iter().collect();
+        sorted_ingredients.sort_unstable_by(|a, b| {
+            if b.0.1 == a.0.1 {
+                match b.1.count.cmp(&a.1.count) {
+                    Ordering::Equal => match b.1.total_cost.cmp(&a.1.total_cost) {
+                        Ordering::Equal => b.0.0.cmp(&a.0.0),
+                        v => v,
+                    },
+                    v => v,
+                }
+            } else if b.0.1 == crafting::Source::Vendor {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            }
+        });
+        for ((ingredient_id, ingredient_source), ingredient) in sorted_ingredients {
             let ingredient_count = ingredient.count.ceil().to_integer();
             let ingredient_count_msg = if ingredient_count > ITEM_STACK_SIZE {
                 let stack_count = ingredient_count / ITEM_STACK_SIZE;
@@ -359,6 +377,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 source_msg,
             );
         }
+
         println!("============");
         println!(
             "Crafting steps: https://gw2efficiency.com/crafting/calculator/a~1!b~1!c~1!d~{}-{}",


### PR DESCRIPTION
Sorts by vendor/TP, then quantity, then total price, then all things being equal, by id - so the sort is stable on repeated runs.

I occasionally re-run after buying some of the ingredients to see if anything has updated, and moderately bothersome to match the list of purchases again.

Vendor at bottom so all TP purchases are together, and vendor is next to crafting station. Quantity next since I often have limited inventory space, and the largest quantity usually crafts down to a smaller amount (better still to order by fastest inventory space reduction, but one step at a time). Price, as the costlier things are more painful if hit by volatility (it _might_ be worth ordering by volatility first - if it were feasible to estimate...). Finally, as noted above, id to ensure the order will always be stable - unless the market changes. Thus, a visual glance can verify if the market has changed proportionally.