### PR TITLE
fix: MF, not M_

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -425,8 +425,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .map(|d| {
                     let s = d.to_string();
                     match &s[..1] {
-                        // take 1st and 7th characters to distinguish Merchant/Mystic Forge
-                        "M" => format!("{}{}", &s[..1], &s[6..7]),
+                        // take 1st and 8th characters to distinguish Merchant/Mystic Forge
+                        "M" => format!("{}{}", &s[..1], &s[7..8]),
                         // take 1st and 3rd characters to distinguish Scribe/Salvage and
                         // Armorsmith/Artificer/Achievement
                         "A" | "S" => format!("{}{}", &s[..1], &s[2..3]),


### PR DESCRIPTION
Counted wrong when distinguishing Merchant from Mystic Forge; ended up with "M " for Mystic Forge, which was kinda not the point. Fixed.