### PR TITLE
fix: Only mark recipes as unknown for crafted items

### DIFF
--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -552,7 +552,7 @@ impl Listing {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-enum RecipeSource {
+pub enum RecipeSource {
     Automatic,
     Discoverable,
     Purchasable,
@@ -655,6 +655,7 @@ impl Recipe {
         output_item_count: i32,
         disciplines: [config::Discipline; A],
         ingredients: &[api::RecipeIngredient],
+        source: RecipeSource,
     ) -> Self {
         Recipe {
             id: Some(id),
@@ -662,7 +663,7 @@ impl Recipe {
             output_item_count,
             disciplines: disciplines.to_vec(),
             ingredients: ingredients.to_vec(),
-            source: RecipeSource::Automatic,
+            source,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -374,8 +374,8 @@ fn calculate_crafting_profit_unknown_recipe_test() {
             );
         }
 
-        // prices chosen such that ingredient 3 will be marked as craftable first
-        // because crafting it is cheaper than buying it from the tp, but then it will
+        // prices chosen such that ingredient 3 will first be marked as craftable
+        // because crafting it is cheaper than buying it from the tp, but it will then
         // have to be discarded because the parent item of ingredient 3 is cheaper to
         // buy from the tp than to craft.
         let sells = if item.id == ingredient_of_ingredient_3.id {


### PR DESCRIPTION
Items marked as craftable may be subsequently unmarked if a parent item ends up being cheaper to buy
from the trading post than to craft.