### PR TITLE
refactor to create Money type

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -350,23 +350,6 @@ impl Item {
             _ => None,
         }
     }
-
-    #[cfg(test)]
-    pub(crate) fn mock(id: u32, name: &str, vendor_value: u32) -> Self {
-        Item {
-            id,
-            name: name.to_string(),
-            vendor_value,
-            item_type: ItemType::Armor,
-            rarity: ItemRarity::Junk,
-            level: 0,
-            flags: vec![],
-            restrictions: vec![],
-            upgrades_into: None,
-            upgrades_from: None,
-            details: None,
-        }
-    }
 }
 
 // When printing an item, add rarity if a trinket, as most trinkets use the same

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use strum::Display;
 
 use crate::config;
 use config::CONFIG;
-use crate::money;
+use crate::money::Money;
 
 
 // types for /commerce/prices
@@ -302,17 +302,17 @@ static VENDOR_ITEMS_CUSTOM_PRICE: phf::Map<u32, u32> = phf_map! {
     90201_u32 => 40000, // Smell-Enhancing Culture; prereq achievement
 };
 impl Item {
-    pub fn vendor_cost(&self) -> Option<money::Money> {
+    pub fn vendor_cost(&self) -> Option<Money> {
         if VENDOR_ITEMS.contains(&self.id) {
             if self.vendor_value > 0 {
                 // standard vendor sell price is generally buy price * 8, see:
                 //  https://forum-en.gw2archive.eu/forum/community/api/How-to-get-the-vendor-sell-price
-                Some(money::Money::from_copper(self.vendor_value * 8))
+                Some(Money::from_copper(self.vendor_value * 8))
             } else {
                 None
             }
         } else if VENDOR_ITEMS_CUSTOM_PRICE.contains_key(&self.id) {
-            Some(money::Money::from_copper(VENDOR_ITEMS_CUSTOM_PRICE[&self.id]))
+            Some(Money::from_copper(VENDOR_ITEMS_CUSTOM_PRICE[&self.id]))
         } else {
             None
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,3 @@
-use num_rational::Rational32;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fmt;
 
@@ -7,15 +6,8 @@ use strum::Display;
 
 use crate::config;
 use config::CONFIG;
+use crate::money;
 
-const TRADING_POST_SALES_COMMISSION: i32 = 15; // %
-
-pub fn subtract_trading_post_sales_commission(v: i32) -> Rational32 {
-    Rational32::new(100 - TRADING_POST_SALES_COMMISSION, 100) * v
-}
-pub fn add_trading_post_sales_commission(v: Rational32) -> i32 {
-    (v / Rational32::new(100 - TRADING_POST_SALES_COMMISSION, 100)).to_integer()
-}
 
 // types for /commerce/prices
 #[derive(Debug, Serialize, Deserialize)]
@@ -25,17 +17,10 @@ pub struct Price {
     pub sells: PriceInfo,
 }
 
-impl Price {
-    pub fn effective_buy_price(&self) -> i32 {
-        (self.buys.unit_price as f32 * (1.0 - TRADING_POST_SALES_COMMISSION as f32 / 100.0)).floor()
-            as i32
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PriceInfo {
-    pub unit_price: i32,
-    pub quantity: i32,
+    pub unit_price: u32,
+    pub quantity: u32,
 }
 
 // types for /recipes
@@ -43,10 +28,10 @@ pub struct PriceInfo {
 pub struct Recipe {
     pub id: u32,
     pub output_item_id: u32,
-    pub output_item_count: i32,
-    time_to_craft_ms: i32,
+    pub output_item_count: u32,
+    time_to_craft_ms: u32,
     pub disciplines: Vec<config::Discipline>,
-    min_rating: i32,
+    min_rating: u16,
     flags: Vec<RecipeFlags>,
     pub ingredients: Vec<RecipeIngredient>,
 }
@@ -69,7 +54,7 @@ impl Recipe {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct RecipeIngredient {
     pub item_id: u32,
-    pub count: i32,
+    pub count: u32,
 }
 
 // types for /items
@@ -81,7 +66,7 @@ pub struct Item {
     item_type: ItemType,
     rarity: ItemRarity,
     level: i32,
-    vendor_value: i32,
+    vendor_value: u32,
     flags: Vec<ItemFlag>,
     restrictions: Vec<String>,
     upgrades_into: Option<Vec<ItemUpgrade>>,
@@ -106,7 +91,7 @@ impl<'de> Deserialize<'de> for ApiItem {
             item_type: ItemType,
             rarity: ItemRarity,
             level: i32,
-            vendor_value: i32,
+            vendor_value: u32,
             flags: Vec<ItemFlag>,
             restrictions: Vec<String>,
             upgrades_into: Option<Vec<ItemUpgrade>>,
@@ -310,24 +295,24 @@ static VENDOR_ITEMS: phf::Set<u32> = phf_set! {
     75087_u32, // Essence of Elegance - buy one at a time
 };
 // Sell price is _not_ buy price * 8
-static SPECIAL_VENDOR_ITEMS: phf::Map<u32, i32> = phf_map! {
+static VENDOR_ITEMS_CUSTOM_PRICE: phf::Map<u32, u32> = phf_map! {
     46747_u32 => 150, // Thermocatalytic Reagent - 1496 for 10
     91739_u32 => 150, // Pile of Compost Starter - 1496 for 10
     91702_u32 => 200, // Pile of Powdered Gelatin Mix - 5 for 1000; prereq achievement
     90201_u32 => 40000, // Smell-Enhancing Culture; prereq achievement
 };
 impl Item {
-    pub fn vendor_cost(&self) -> Option<i32> {
+    pub fn vendor_cost(&self) -> Option<money::Money> {
         if VENDOR_ITEMS.contains(&self.id) {
             if self.vendor_value > 0 {
                 // standard vendor sell price is generally buy price * 8, see:
                 //  https://forum-en.gw2archive.eu/forum/community/api/How-to-get-the-vendor-sell-price
-                Some(self.vendor_value * 8)
+                Some(money::Money::from_copper(self.vendor_value * 8))
             } else {
                 None
             }
-        } else if SPECIAL_VENDOR_ITEMS.contains_key(&self.id) {
-            Some(SPECIAL_VENDOR_ITEMS[&self.id])
+        } else if VENDOR_ITEMS_CUSTOM_PRICE.contains_key(&self.id) {
+            Some(money::Money::from_copper(VENDOR_ITEMS_CUSTOM_PRICE[&self.id]))
         } else {
             None
         }
@@ -367,7 +352,7 @@ impl Item {
     }
 
     #[cfg(test)]
-    pub(crate) fn mock(id: u32, name: &str, vendor_value: i32) -> Self {
+    pub(crate) fn mock(id: u32, name: &str, vendor_value: u32) -> Self {
         Item {
             id,
             name: name.to_string(),
@@ -412,7 +397,7 @@ pub struct ItemListings {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Listing {
-    pub listings: i32,
-    pub unit_price: i32,
-    pub quantity: i32,
+    pub listings: u32,
+    pub unit_price: u32,
+    pub quantity: u32,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,9 +19,9 @@ pub const CACHE_PREFIX: &str = "cache_";
 pub struct CraftingOptions {
     pub include_timegated: bool,
     pub include_ascended: bool,
-    pub count: Option<i32>,
+    pub count: Option<u32>,
     pub threshold: Option<u32>,
-    pub value: Option<i32>,
+    pub value: Option<u32>,
 }
 
 #[derive(Default)]
@@ -174,11 +174,11 @@ struct Opt {
 
     /// Limit the maximum number of items produced for a recipe
     #[structopt(short, long)]
-    count: Option<i32>,
+    count: Option<u32>,
 
     /// Calculate profit based on a fixed value instead of from buy orders
     #[structopt(long)]
-    value: Option<i32>,
+    value: Option<u32>,
 
     /// Threshold - min profit per item in copper
     #[structopt(long)]

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -686,25 +686,6 @@ impl Recipe {
             || self.output_item_id == 79817  // Dragon Hatchling Doll Frame
             || self.output_item_id == 43772 // Charged Quartz Crystal
     }
-
-    #[cfg(test)]
-    pub(crate) fn mock<const A: usize>(
-        id: u32,
-        output_item_id: u32,
-        output_item_count: u32,
-        disciplines: [config::Discipline; A],
-        ingredients: &[api::RecipeIngredient],
-        source: RecipeSource,
-    ) -> Self {
-        Recipe {
-            id: Some(id),
-            output_item_id,
-            output_item_count,
-            disciplines: disciplines.to_vec(),
-            ingredients: ingredients.to_vec(),
-            source,
-        }
-    }
 }
 
 trait OptionInnerMin<T> {

--- a/src/gw2efficiency.rs
+++ b/src/gw2efficiency.rs
@@ -58,7 +58,7 @@ pub struct Recipe {
     pub name: String, // used only in error output
     pub output_item_id: u32,
     #[serde(deserialize_with = "treat_error_as_none")]
-    pub output_item_count: Option<i32>,
+    pub output_item_count: Option<u32>,
     #[serde(deserialize_with = "strum_discipline")]
     pub disciplines: Vec<config::Discipline>,
     pub ingredients: Vec<api::RecipeIngredient>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod api;
+pub mod config;
+pub mod crafting;
+pub mod gw2efficiency;
+pub mod request;
+pub mod money;

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!(
             "Sell at: {}, Money Required: {}, Breakeven price: {}",
             price_msg,
-            profitable_item.crafting_cost.include_trading_post_listing_fee(),
+            profitable_item.crafting_cost.increase_by_listing_fee(),
             profitable_item.breakeven,
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod money;
 mod tests;
 
 use config::CONFIG;
+use money::Money;
 
 const ITEM_STACK_SIZE: u32 = 250; // GW2 uses a "stack size" of 250
 
@@ -354,7 +355,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &tp_prices_map,
             &CONFIG.crafting,
         ) {
-            let effective_buy_price = money::Money::from_copper(tp_prices.buys.unit_price)
+            let effective_buy_price = Money::from_copper(tp_prices.buys.unit_price)
                 .trading_post_sale_revenue();
             if effective_buy_price > crafting_cost {
                 profitable_item_ids.push(*item_id);
@@ -528,7 +529,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", header);
     println!("{}", "=".repeat(header.len()));
 
-    let total_profit: money::Money = profitable_items.iter().map(|item| item.profit).sum();
+    let total_profit: Money = profitable_items.iter().map(|item| item.profit).sum();
     println!("Total: {}", total_profit);
 
     if let Some(writer) = &mut csv_writer {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,7 @@ use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
-mod api;
-mod config;
-mod crafting;
-mod gw2efficiency;
-mod request;
-mod money;
-#[cfg(test)]
-mod tests;
+use gw2_arbitrage::*;
 
 use config::CONFIG;
 use money::Money;

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
 
+        if !profitable_item.leftovers.is_empty() {
+            println!("Leftovers:");
+            // count name, breakeven: y
+            for (leftover_id, (count, cost)) in profitable_item.leftovers.iter() {
+                println!(
+                    "{} {}, breakeven: {} each",
+                    count,
+                    items_map
+                        .get(&leftover_id)
+                        .map_or_else(|| "???".to_string(), |item| item.to_string()),
+                    cost.trading_post_listing_price(),
+                );
+            }
+        }
+
         return Ok(());
     }
 

--- a/src/money.rs
+++ b/src/money.rs
@@ -1,0 +1,156 @@
+use num_rational::Ratio;
+use num_traits::{Zero, ToPrimitive};
+
+use std::fmt;
+
+// https://wiki.guildwars2.com/wiki/Trading_Post
+// Listing Fee (5%) — This nonrefundable cost covers listing and holding your items for sale. This
+// fee has a minimum of 1c and is immediately taken from your wallet when you list or instantly
+// sell an item.
+// Exchange Fee (10%) — This fee is the Trading Post's cut of the profit. This fee has a minimum of
+// 1c and is deducted from coins delivered to the seller after a successful sale.
+const TRADING_POST_LISTING_FEE: u32 = 5; // %
+const TRADING_POST_EXCHANGE_FEE: u32 = 10; // %
+
+type Rational32u = Ratio<u32>;
+
+#[derive(Debug, Copy, Clone, Eq)]
+pub struct Money {
+    copper: Rational32u,
+    // karma: Rational32u,
+}
+impl Money {
+    pub fn from_copper(copper: u32) -> Self {
+        Self {
+            copper: Rational32u::from(copper),
+        }
+    }
+    pub fn to_copper_value(self) -> u32 {
+        self.copper.to_integer()
+    }
+
+    pub fn include_trading_post_listing_fee(self) -> Money {
+        Money {
+            copper: self.copper * Rational32u::new(100 + TRADING_POST_LISTING_FEE, 100),
+        }
+    }
+    pub fn trading_post_listing_price(self) -> Money {
+        Money {
+            copper: (self.copper / Rational32u::new(100 - TRADING_POST_LISTING_FEE - TRADING_POST_EXCHANGE_FEE, 100))
+                .ceil(),
+        }
+    }
+    pub fn trading_post_sale_revenue(self) -> Money {
+        Money {
+            copper: self.copper * Rational32u::new(100 - TRADING_POST_LISTING_FEE - TRADING_POST_EXCHANGE_FEE, 100),
+        }
+    }
+
+    // integer division rounding up
+    // see: https://stackoverflow.com/questions/2745074/fast-ceiling-of-an-integer-division-in-c-c
+    pub fn div_u32_ceil(self, y: u32) -> Money {
+        Money {
+            copper: (self.copper + y - 1) / y,
+        }
+    }
+
+    // Gives an approximate ratio between two money values; for profit on cost
+    pub fn percent(self, other: Self) -> f64 {
+        self.copper.to_f64().unwrap() / other.copper.to_f64().unwrap()
+    }
+
+    fn copper_to_string(copper: u32) -> String {
+        let gold = copper / 10000;
+        let silver = (copper - gold * 10000) / 100;
+        let copper = copper - gold * 10000 - silver * 100;
+        format!("{}.{:02}.{:02}g", gold, silver, copper)
+    }
+}
+impl fmt::Display for Money {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Money::copper_to_string(self.copper.to_integer()))
+    }
+}
+impl Default for Money {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+impl Zero for Money {
+    fn zero() -> Self {
+        Self {
+            copper: Rational32u::zero(),
+        }
+    }
+    fn is_zero(&self) -> bool {
+        self.copper.is_zero()
+    }
+}
+impl std::ops::Add for Money {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            copper: self.copper + other.copper,
+        }
+    }
+}
+impl std::ops::Sub for Money {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        debug_assert!(self.copper >= other.copper);
+        Self {
+            copper: self.copper - other.copper,
+        }
+    }
+}
+impl std::ops::AddAssign for Money {
+    fn add_assign(&mut self, other: Self) {
+        *self = Self {
+            copper: self.copper + other.copper,
+        }
+    }
+}
+impl std::ops::Mul<u32> for Money {
+    type Output = Self;
+
+    fn mul(self, other: u32) -> Self {
+        Self {
+            copper: self.copper * other,
+        }
+    }
+}
+impl std::ops::Div<u32> for Money {
+    type Output = Self;
+
+    fn div(self, other: u32) -> Self {
+        Self {
+            copper: self.copper / other,
+        }
+    }
+}
+impl PartialEq for Money {
+    fn eq(&self, other: &Self) -> bool {
+        self.copper == other.copper
+    }
+}
+impl PartialOrd for Money {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for Money {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.copper.cmp(&other.copper)
+    }
+}
+impl std::iter::Sum for Money {
+    fn sum<I: Iterator<Item = Money>>(iter: I) -> Self {
+        let mut sink = Money::zero();
+        for src in iter {
+            sink.copper += src.copper;
+        }
+        sink
+    }
+}

--- a/src/money.rs
+++ b/src/money.rs
@@ -27,7 +27,7 @@ impl Money {
         }
     }
     pub fn to_copper_value(self) -> u32 {
-        self.copper.to_integer()
+        self.copper.ceil().to_integer()
     }
 
     fn fee(&self, percent: u32) -> Rational32u {
@@ -35,8 +35,9 @@ impl Money {
     }
 
     pub fn trading_post_sale_revenue(self) -> Money {
+        let fees = self.fee(TRADING_POST_EXCHANGE_FEE) + self.fee(TRADING_POST_LISTING_FEE);
         Money {
-            copper: self.copper - self.fee(TRADING_POST_EXCHANGE_FEE) - self.fee(TRADING_POST_LISTING_FEE),
+            copper: if self.copper > fees { self.copper - fees } else { 0.into() },
         }
     }
     /// Has an error of at most 1 copper too high (could have broken even at one copper less)

--- a/tests/profit.rs
+++ b/tests/profit.rs
@@ -246,6 +246,7 @@ fn calculate_crafting_profit_agony_infusion_profitable_test() {
             min_sell: Money::from_copper(7982200),
             // (1100000 * 4 + 3 * 150) / (85 / 100)
             breakeven: Money::from_copper(5177000),
+            leftovers: Default::default(),
         })
     );
 }
@@ -322,6 +323,7 @@ fn calculate_crafting_profit_with_output_item_count_test() {
             max_sell: Money::from_copper(200),
             min_sell: Money::from_copper(198),
             breakeven: profitable_item.as_ref().unwrap().breakeven, // inexact, test below
+            leftovers: Default::default(),
         })
     );
     assert_eq!(
@@ -358,6 +360,7 @@ fn calculate_crafting_profit_with_output_item_count_test() {
             min_sell: Money::from_copper(198),
             // ((2*94 + 45) / 3) / (85/100)
             breakeven: Money::from_copper(92),
+            leftovers: Default::default(),
         })
     );
 }
@@ -590,22 +593,25 @@ fn calculate_crafting_profit_with_subitem_leftovers() {
         + (30 + 50 + 20) // +1 = 6
         + (50 * 2 * 11 + 21 * 11) // +11 = 17
         + (50 * 2 * 30 + 25 * 5 * 6) // +30 = 47
-        + (50 * 2 * 4 + 30 * 4), // +34 = 51
-                                 // One leftover, not profitable at 100
+        + (50 * 2 * 4 + 30 * 4), // +4 = 51
     );
+    // One leftover, not profitable at 100
+    let mut leftovers: HashMap<u32, (u32, Money)> = HashMap::new();
+    leftovers.insert(2100, (1, Money::from_copper(30)));
     assert_eq!(
         profitable_item,
         Some(crafting::ProfitableItem {
             id: 1000,
             crafting_cost,
-            crafting_steps: 51, // TODO: wrong, should be 51 + 8
+            crafting_steps: 59,
             count: 51,
-            profit: Money::from_copper(200 + 155 * 50).trading_post_sale_revenue() - crafting_cost,
+            profit: calc_revenue(vec![(50, 155), (1, 200)]) - crafting_cost,
             unknown_recipes: Default::default(),
             max_sell: Money::from_copper(200),
-            min_sell: Money::from_copper(150),
+            min_sell: Money::from_copper(155),
             // (50 * 2 + 30) / (85/100)
             breakeven: Money::from_copper(153),
+            leftovers,
         })
     );
 }


### PR DESCRIPTION
Preparation to handle recipe ingredients which cost karma.

The use of u32 instead of i32 might be controversial, or the removal of Ratio's when dealing with discrete counts. However, both may have been chosen for convenience.

Also fixes the test cases which I've broken w/other commits.

Added sales cost into the crafting total as well in the process as an incidental, not worth splitting out.