### PR TITLE
Fixes to talk to API turned back on for EoD

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -169,6 +169,8 @@ pub enum ItemType {
     Gizmo,
     Key,
     MiniPet,
+    Quux, // Jade bot item; may be a temporary name
+    Qux, // Jade bot core; may be a temporary name
     Tool,
     Trait,
     Trinket,


### PR DESCRIPTION
Just two types added to items; both are likely temporary labels.